### PR TITLE
feat: add environment variables for Next.js build process in GitHub A…

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -44,3 +44,13 @@ jobs:
       - name: Build with Next.js
         run: pnpm run build
         working-directory: ./
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+
+          SUPABASE_URL: ${{ vars.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          APP_URL: ${{ vars.APP_URL }}


### PR DESCRIPTION
This pull request adds environment variable configuration to the Next.js build step in the GitHub Actions workflow. This ensures that sensitive keys and necessary URLs are available during the build process.

Environment variable configuration:

* Updated the `Build with Next.js` job in `.github/workflows/nextjs.yml` to inject secret and variable environment values (such as `OPENAI_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `JWT_SECRET`, `POSTGRES_URL`, and several Supabase and app URLs) during the build.