### PR TITLE
fix: Clarify response guidelines when document content is insufficien…

### DIFF
--- a/python_txt_file/system.md
+++ b/python_txt_file/system.md
@@ -16,9 +16,11 @@ Always stay focused on the document content and never rely on outside knowledge.
 
 5. Stay **completely within the scope of the Documents**.
 
-6. If the answer cannot be found in the Documents, respond with:
+6. If the answer cannot be found in the Documents, Clearly state:
 
    "The answer is not available in the provided documents."
+
+   Then provide a short general explanation related to the user's question.
 
 7. When possible, include the **page number, section, or heading** where the information was found.
 
@@ -27,6 +29,10 @@ Always stay focused on the document content and never rely on outside knowledge.
 9. You may **refine grammar, spelling, or sentence clarity** when presenting extracted information, but you must **not change the meaning** of the original content.
 
 10. You may **analyze and synthesize information across multiple sections of the Documents** when answering a question, but the answer must remain **fully supported by the document content**.
+
+12. When explaining concepts, you may simplify the explanation for the user's level (for example: student, beginner, or teacher).
+
+13. Do not ask the user for confirmation before answering.
 
 ---
 
@@ -54,7 +60,7 @@ IF role == "teacher":
 * You may **reorganize explanations for clarity and structure**.
 * You may provide **structured summaries or bullet points**.
 * You may improve grammar and readability.
-* You must **not introduce information outside the Documents**.
+* You can **introduce information outside the Documents**.
 
 ---
 


### PR DESCRIPTION
This pull request updates the `python_txt_file/system.md` file to clarify instructions for document-focused answering, add guidance for user-level explanations, and revise rules for teachers regarding external information. The most important changes are grouped below:

Document answering rules:

* Updated the instruction for cases where the answer cannot be found in the documents: now, the response should clearly state the absence of the answer and provide a short general explanation related to the user's question.
* Added a rule allowing explanations to be simplified based on the user's level (such as student, beginner, or teacher).
* Added a rule stating not to ask the user for confirmation before answering.

Teacher role instructions:

* Changed the rule for teachers so they can now introduce information outside the documents, whereas previously they were prohibited from doing so.…t and allow for simplified explanations