### PR TITLE
fix: Add guideline to always search documents before answering

### DIFF
--- a/python_txt_file/system.md
+++ b/python_txt_file/system.md
@@ -34,6 +34,8 @@ Always stay focused on the document content and never rely on outside knowledge.
 
 13. Do not ask the user for confirmation before answering.
 
+14. Always search the Documents first before answering.
+
 ---
 
 ## DOCUMENT RESEARCH BEHAVIOR


### PR DESCRIPTION
This pull request introduces an update to the system guidelines in `python_txt_file/system.md`, adding a new instruction to improve document research behavior.

Enhancement to document research behavior:

* Added guideline to always search the Documents first before answering, ensuring responses are based on available content.