### PR TITLE
feat: Update deployment workflow to include Python setup and testing

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,4 +1,4 @@
-name: Deploy Next.js site to Pages
+name: Deploy Next.js and Python to Pages
 
 on:
   push:
@@ -33,8 +33,39 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      - name: Install dependencies
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Node dependencies
         run: pnpm install
+        working-directory: ./
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r python_txt_file/requirements.txt
+          pip install flake8 pytest
+        working-directory: ./
+
+      - name: Lint Python code with flake8
+        run: |
+          # Stop the build if there are Python syntax errors or undefined names
+          flake8 python/ --count --select=E9,F63,F7,F82 --show-source --statistics
+          # Exit-zero treats all errors as warnings
+          flake8 python/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        working-directory: ./
+
+      - name: Test Python code
+        run: |
+          # Run Python tests if they exist
+          if [ -d "python/tests" ]; then
+            pytest python/tests -v
+          else
+            echo "No Python tests found, skipping..."
+          fi
         working-directory: ./
 
       - name: Checking ESLint with Next.js
@@ -52,8 +83,16 @@ jobs:
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           API_KEY: ${{ secrets.API_KEY }}
+          APP_URL: ${{ vars.APP_URL }}
           
           # Public variables
           NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Check Python application
+        run: |
+          echo "Checking Python application..."
+          python --version
+          echo "Python dependencies installed successfully"
+        working-directory: ./
           


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying the Next.js site, expanding it to also support Python code. The changes add steps for setting up Python, installing dependencies, running lint checks and tests, and updating environment variables for deployment.

**Python integration and CI enhancements:**

* Added Python setup using `actions/setup-python`, including dependency installation from `requirements.txt` and installation of `flake8` and `pytest` for linting and testing.
* Introduced steps to lint Python code with `flake8` and run Python tests with `pytest`, ensuring code quality and correctness.
* Added a step to check the Python application, including version verification and confirmation of dependency installation.

**Workflow and environment updates:**

* Changed workflow name from "Deploy Next.js site to Pages" to "Deploy Next.js and Python to Pages" to reflect the expanded scope.
* Updated environment variables to include `APP_URL` for deployment configuration.