### PR TITLE
Adjust chat component dimensions and padding for layout improvement

### DIFF
--- a/src/components/chat/main/css/styles.module.css
+++ b/src/components/chat/main/css/styles.module.css
@@ -15,17 +15,20 @@
 }
 .chat {
     width: 100%;
-    height: 80vh;
+    height: 75vh;
     overflow-y: auto; 
     align-items: flex-start;
     flex: 1;
     gap: 1rem;
     margin: 70px;
 }
+.chat div{
+    padding: 0 0 1rem 0;
+}
 .response {
     width: min(800px, 90dvw);
     height: auto;
-    margin: 2rem auto;
+    margin: 1rem auto;
 }
 .user_respones {
     width: 100%;
@@ -47,7 +50,7 @@
     flex-direction: column; 
     justify-content: flex-start;
     align-items: flex-start;
-    padding: 2rem 1rem;
+    padding: 0 0 2rem 0;
     line-height: 2.5rem;
     backdrop-filter: blur(100px);
 }
@@ -94,11 +97,11 @@
 }
 
 .ask {
-    width: min(800px, 90dvw);
+    width: min(900px, 90dvw);
     height: auto;
     overflow: hidden;
     border-radius: 5px;
-    padding: 0 1.2rem;
+    padding: 0.3rem 1.2rem;
     margin: 1.3rem 3rem;
     background: var(--default-color-white-2);
     box-shadow: 0 0 2px 1px var(--foreground);
@@ -111,11 +114,12 @@
     justify-content: flex-start;
     align-items: flex-start;
     display: flex;
+    width: min(100%, 670px);
 }
 .plushie_talk div {
-    margin: 0 1rem;
+    margin: 0 0.2rem;
     background: var(--primary);
-    padding: 1.2rem;
+    padding: 1rem 1.5rem;
     border-radius: 10px;
     color: var(--default-color-white);
 }


### PR DESCRIPTION
This pull request makes several adjustments to the chat interface's CSS styles to improve layout, spacing, and responsiveness. The main focus is on refining the chat container's dimensions, padding, and the appearance of chat elements for a more polished user experience.

**Layout and spacing improvements:**

* Reduced the `.chat` container height from `80vh` to `75vh`, adjusted its margin, and added padding to its child divs for better spacing.
* Decreased margin for `.response` and changed `.user_respones` padding for more compact message display. [[1]](diffhunk://#diff-bf9753f66f002e2c68b8debdf3de55171876fd5baa2f3f85fb4aec91c3276452L18-R31) [[2]](diffhunk://#diff-bf9753f66f002e2c68b8debdf3de55171876fd5baa2f3f85fb4aec91c3276452L50-R53)

**Chat element appearance and responsiveness:**

* Increased the `.ask` element's max width to `900px` and added slight vertical padding for improved input field appearance.
* Set a maximum width for `.plushie_talk` and adjusted margin and padding for its child divs to create a more consistent and visually appealing chat bubble.