### PR TITLE
Implement JWT verification for user redirection on key pages

### DIFF
--- a/src/app/(pages)/auth/signin/page.tsx
+++ b/src/app/(pages)/auth/signin/page.tsx
@@ -1,6 +1,22 @@
+"use client";
 import { SignIn } from "@/components/auth";
+import { Fetch_to } from "@/utilities";
+import api_link from "@/config/conf/json_config/fetch_url.json";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function SignInPage() {
+    const router = useRouter();
+
+    useEffect(() => {
+        async function check() {
+            const response = await Fetch_to(api_link.jwt.verify);
+            if (response.success) return router.push("/chat");
+        }
+        check();
+    }, []);
+
+    
 
     return(
         <main className="auth_page">

--- a/src/app/(pages)/auth/signup/page.tsx
+++ b/src/app/(pages)/auth/signup/page.tsx
@@ -1,6 +1,20 @@
+"use client";
 import { SignUp } from "@/components/auth";
+import { Fetch_to } from "@/utilities";
+import api_link from "@/config/conf/json_config/fetch_url.json";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function SignupPage() {
+    const router = useRouter();
+
+    useEffect(() => {
+            async function check() {
+                const response = await Fetch_to(api_link.jwt.verify);
+                if (response.success) return router.push("/chat");
+            }
+            check();
+        }, []);
 
     return(
         <main className="auth_page">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,22 @@ import {
 	Fx_effect
 } from "@/components/landpage";
 import { useState } from "react";
+import { Fetch_to } from "@/utilities";
+import api_link from "@/config/conf/json_config/fetch_url.json";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function Home() {
+	const router = useRouter();
 	const [show, setShow] = useState(false);
+
+	useEffect(() => {
+        async function check() {
+            const response = await Fetch_to(api_link.jwt.verify);
+            if (response.success) return router.push("/chat");
+        }
+        check();
+    }, []);
 
 	return (
 		<main className="landpage">

--- a/src/components/chat/main/index.tsx
+++ b/src/components/chat/main/index.tsx
@@ -30,9 +30,9 @@ export default function Main({ emailRes, currentPdf }: MainProps) {
 
     useEffect(() => {
         if (chatEndRef.current) {
-            chatEndRef.current.scrollIntoView({ behavior: "smooth" });
+            chatEndRef.current.scrollIntoView();
         }
-    }, [messages, animatedText]);
+    }, [messages]);
 
     useEffect(() => {
         setEmail(emailRes);


### PR DESCRIPTION
This pull request improves the authentication flow and user experience across the sign-in, sign-up, and landing pages by automatically redirecting authenticated users to the chat page. It also includes a minor update to the chat component's scroll behavior.

Authentication and user flow improvements:

* Added a check on the sign-in (`page.tsx` in `auth/signin`), sign-up (`page.tsx` in `auth/signup`), and landing (`page.tsx`) pages to verify if the user is already authenticated using `Fetch_to` and the JWT verification endpoint; if authenticated, the user is redirected to `/chat`. [[1]](diffhunk://#diff-645c55c2b34122bac816e503f132dfede707d1e8b31e7d8e33e451cb6f3606ecR1-R19) [[2]](diffhunk://#diff-7f2221cc508a799574fff872e4f6395276994a2543be0bdc403c6ab40995d4a9R1-R17) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR10-R26)

UI behavior update:

* Updated the chat component (`src/components/chat/main/index.tsx`) to remove the "smooth" scroll behavior when auto-scrolling to the latest message, ensuring immediate visibility of new messages.…to redirect authenticated users to chat