### PR TITLE
Add "use client" directive for React_Spinners and SweetAlert2 compatibility

### DIFF
--- a/src/utilities/React_Spinners.tsx
+++ b/src/utilities/React_Spinners.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Puff } from "react-loader-spinner";
 
 type StatusType = {

--- a/src/utilities/SweetAlert2.ts
+++ b/src/utilities/SweetAlert2.ts
@@ -1,3 +1,4 @@
+"use client";
 import Swal from 'sweetalert2';
 
 type SweetAlertIconType = 'success' | 'error' | 'warning' | 'info' | 'question' | 'process';


### PR DESCRIPTION
This pull request adds the `"use client"` directive to two utility files to ensure they are treated as client components in a Next.js application. This change is important for compatibility with features that require client-side execution, such as UI components and browser-based libraries.

Client component enforcement:

* Added `"use client"` directive to the top of `src/utilities/React_Spinners.tsx` to ensure proper client-side behavior for spinner components.
* Added `"use client"` directive to the top of `src/utilities/SweetAlert2.ts` to enable client-side execution for SweetAlert2 modals.…or improved compatibility