### PR TITLE
Fix primary color values for CSS and component consistency

### DIFF
--- a/src/config/conf/css_config/config.css
+++ b/src/config/conf/css_config/config.css
@@ -2,7 +2,7 @@
 	--background_linear_1: #017d93;
 	--background_linear_2: #3fa5b7;
 	--foreground: #181818;
-	--primary: #1A54B8;
+	--primary: #123a9b;
 	--secondary: #3fa5b7;
 	/* Alternative Colors */
 	--default-color-white: #e9e9e9;

--- a/src/utilities/React_Spinners.tsx
+++ b/src/utilities/React_Spinners.tsx
@@ -12,7 +12,7 @@ export default function React_Spinners({status} : StatusType) {
             visible={true}
             height="80"
             width="80"
-            color="#1A54B8"
+            color="#123a9b"
             ariaLabel="puff-loading"
             wrapperStyle={{}}
             wrapperClass=""

--- a/src/utilities/SweetAlert2.ts
+++ b/src/utilities/SweetAlert2.ts
@@ -25,7 +25,7 @@ export default function SweetAlert2(
     confirmButtonText: ok,
     cancelButtonText: cancel,
     allowOutsideClick: false,
-    background: '#1A54B8',  
+    background: '#123a9b',  
     color: '#fff',         
     didOpen: () => {
       if (showLoading || isProcess) {


### PR DESCRIPTION
This pull request updates the primary brand color throughout the application to ensure consistency across styles and UI components. The main change is the switch from the old primary color `#1A54B8` to the new primary color `#123a9b`.

**Brand color update:**

* Changed the `--primary` CSS variable in `config.css` from `#1A54B8` to `#123a9b` to update the application's main color scheme.
* Updated the `color` property for the spinner component in `React_Spinners.tsx` to use the new primary color `#123a9b`.
* Set the SweetAlert2 dialog background color to the new primary color `#123a9b` in `SweetAlert2.ts`.