### PR TITLE
Fix Python requirements file path in setup scripts and workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r python_txt_file/requirements.txt
+          pip install -r python/python_txt_file/requirements.txt
           pip install flake8 pytest
         working-directory: ./
 

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ python3 -m pip install --upgrade pip
 
 # Install Python packages
 echo -e "${YELLOW}==> Installing Python packages...${RESET}"
-pip install -r python_txt_file/requirements.txt
+pip install -r python/python_txt_file/requirements.txt
 
 echo -e "${BLUE}<==> Building Next.js app... <==>${RESET}"
 echo -e "${YELLOW}==> Running lint...${RESET}"


### PR DESCRIPTION
This pull request updates the path to the Python requirements file in both the GitHub Actions workflow and the setup script to reflect a new directory structure. The requirements file has been moved from `python_txt_file/requirements.txt` to `python/python_txt_file/requirements.txt`.

Dependency management updates:

* Updated the path to the Python requirements file in the `.github/workflows/nextjs.yml` workflow to `python/python_txt_file/requirements.txt`.
* Updated the path to the Python requirements file in the `setup.sh` script to `python/python_txt_file/requirements.txt`.