### PR TITLE
Change form position style from fixed to relative based on status

### DIFF
--- a/src/components/chat/main/index.tsx
+++ b/src/components/chat/main/index.tsx
@@ -199,7 +199,7 @@ export default function Main({ emailRes, currentPdf }: MainProps) {
                     
                )}
               
-            <form className={`${styles.ask} `} onSubmit={handleSubmit} style={{ position: status ? "fixed" : "initial" }}>
+            <form className={`${styles.ask} `} onSubmit={handleSubmit} style={{ position: status ? "fixed" : "relative" }}>
                 <textarea
                 id="chat"
                 name="ask"


### PR DESCRIPTION
This pull request makes a minor adjustment to the chat input form's positioning logic in the `Main` component. The form's CSS `position` property now uses "relative" instead of "initial" when the `status` condition is false, which may help with layout consistency.

- Changed the `position` style of the chat form from "initial" to "relative" when `status` is false in the `Main` component (`src/components/chat/main/index.tsx`).