### PR TITLE
Improve checkbox alignment and styles in sign-in components

### DIFF
--- a/src/components/auth/create_password/css/styles.module.css
+++ b/src/components/auth/create_password/css/styles.module.css
@@ -102,17 +102,19 @@
 }
 .checkbox {
     display: flex;
+    align-items: center; 
     width: 100%;
-    height: 60px;
-    padding: 0;
-    margin: 0 auto;
+    min-height: 60px; 
+    gap: 8px; 
 }
+
 .checkbox p {
-    margin: 15px 0 0 5px;
+    margin: 0;
+    line-height: 1.4;
 }
 .checkbox input {
     width: 20px;
     height: 20px;
     cursor: pointer;
-    margin: 15px 0;
+    flex-shrink: 0; 
 }

--- a/src/components/auth/create_password/css/styles.module.css
+++ b/src/components/auth/create_password/css/styles.module.css
@@ -114,5 +114,5 @@
     width: 20px;
     height: 20px;
     cursor: pointer;
-    bottom: 0;
+    margin: 0;
 }

--- a/src/components/auth/create_password/css/styles.module.css
+++ b/src/components/auth/create_password/css/styles.module.css
@@ -108,11 +108,11 @@
     margin: 0 auto;
 }
 .checkbox p {
-    margin: 17px 0 0 10px;
+    margin: 15px 0 0 5px;
 }
 .checkbox input {
     width: 20px;
     height: 20px;
     cursor: pointer;
-    margin: 0;
+    margin: 15px 0;
 }

--- a/src/components/auth/create_password/index.tsx
+++ b/src/components/auth/create_password/index.tsx
@@ -106,7 +106,7 @@ export default function Create_Password() {
                         {message && (
                             <p className={status ?  "error" : "success"}>{message}</p>
                         )}
-                         <span className={`display_flex_center ${styles.checkbox}`}>
+                         <span className={styles.checkbox}>
                             <input type="checkbox" required />
                             <p>I agree to the <Link href={"/privacy"}>Privacy Policy</Link> & <Link href={"/terms"}>Terms of Conditions</Link></p>
                         </span>

--- a/src/components/auth/signin/css/styles.module.css
+++ b/src/components/auth/signin/css/styles.module.css
@@ -130,5 +130,5 @@
     width: 20px;
     height: 20px;
     cursor: pointer;
-    bottom: 0;
+    margin: 0;
 }

--- a/src/components/auth/signin/css/styles.module.css
+++ b/src/components/auth/signin/css/styles.module.css
@@ -118,17 +118,18 @@
 }
 .checkbox {
     display: flex;
+    align-items: center; 
     width: 100%;
-    height: 60px;
-    padding: 0;
-    margin: 0 auto;
+    min-height: 60px; 
+    gap: 8px; 
 }
 .checkbox p {
-    margin: 15px 0 0 5px;
+    margin: 0;
+    line-height: 1.4;
 }
 .checkbox input {
     width: 20px;
     height: 20px;
     cursor: pointer;
-    margin: 15px 0;
+    flex-shrink: 0; 
 }

--- a/src/components/auth/signin/css/styles.module.css
+++ b/src/components/auth/signin/css/styles.module.css
@@ -124,11 +124,11 @@
     margin: 0 auto;
 }
 .checkbox p {
-    margin: 17px 0 0 10px;
+    margin: 15px 0 0 5px;
 }
 .checkbox input {
     width: 20px;
     height: 20px;
     cursor: pointer;
-    margin: 0;
+    margin: 15px 0;
 }

--- a/src/components/auth/signin/index.tsx
+++ b/src/components/auth/signin/index.tsx
@@ -127,7 +127,7 @@ export default function SignIn() {
                             <p>I agree to the <Link href={"/privacy"} onClick={() => {Progress(true);}}>Privacy Policy</Link> & <Link href={"/terms"} onClick={() => {Progress(true);}} >Terms of Conditions</Link></p>
                         </span>
                        
-                        <section className={`${styles.buttons} `}>
+                        <section className={`${styles.buttons}`}>
                             <button>Log In</button>
                         </section>
                         <p>Register an Account? <Link href={"/auth/register"} onClick={() => {Progress(true);}}>Registered</Link></p>


### PR DESCRIPTION
This pull request improves the layout and styling of the checkbox component in both the "Create Password" and "Sign In" authentication forms for better alignment, spacing, and responsiveness. It also simplifies the JSX structure in the "Create Password" component.

**Styling and Layout Improvements:**

* Updated `.checkbox` styles in `src/components/auth/create_password/css/styles.module.css` and `src/components/auth/signin/css/styles.module.css` to use `align-items: center`, `min-height`, and `gap` for better alignment and spacing. Adjusted margins and input sizing for improved appearance and consistency. [[1]](diffhunk://#diff-7e6b3d6982e469e4ff251ba6b789c1f9f9853f8587010df84566bbfd7a08a6d9R105-R119) [[2]](diffhunk://#diff-6f254ba080050cdd9f0541a639788ffde62c62aaf57c4f96b5cbbdcd4eecb12dR121-R134)

**Code Simplification:**

* Simplified the checkbox wrapper in `src/components/auth/create_password/index.tsx` by removing the unnecessary `display_flex_center` class, relying solely on the improved CSS for layout.