### PR TITLE
Update start_url in manifest to point to registration page

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -7,7 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
     description: "LACO PWA Web Development App",
     id: "/",
     scope: "/",
-    start_url: "/auth/signup",
+    start_url: "/auth/register",
     display: "standalone",
     orientation: "portrait",
     background_color: "#1A54B8",


### PR DESCRIPTION
This pull request makes a small update to the PWA manifest configuration. The `start_url` has been changed from `/auth/signup` to `/auth/register` to reflect the correct authentication route.