### PR TITLE
Update ESLint configuration to use tsconfig and ignore mobile directory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,7 @@ export default [
       parser: tsParser,
       parserOptions: {
         ecmaFeatures: { jsx: true },
-        project: "./tsconfig.json",
+        project: "./tsconfig.eslint.json",
       },
       globals: {
         ...globals.browser,
@@ -108,6 +108,12 @@ export default [
   },
 
   {
-    ignores: ["**/.next/**", "**/node_modules/**", "**/.venv/**", "**/python/**"],
+    ignores: [
+      "**/.next/**",
+      "**/node_modules/**",
+      "**/.venv/**",
+      "**/python/**",
+      "**/mobile/**",
+    ],
   },
 ];

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "next-env.d.ts",
+    "next.config.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.mts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    ".next/dev/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "mobile"
+  ]
+}


### PR DESCRIPTION
This pull request updates the ESLint configuration to improve TypeScript project handling and exclude mobile-related files from linting. The most important changes are:

**ESLint Configuration Updates:**

* Changed the `project` path in the TypeScript parser options from `./tsconfig.json` to the new `./tsconfig.eslint.json` for more targeted linting.
* Added a new `tsconfig.eslint.json` configuration file that extends the main TypeScript config but specifically includes only relevant files and excludes the `mobile` directory and `node_modules`.
* Updated the ESLint `ignores` list to also exclude the `mobile` directory from linting.…mobile directory to ignores