### PR TITLE
Update Chat_bot layout with Poppins font and navigation button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,16 @@
 import { MetadataUtils } from "@/utilities";
-import { Roboto, Roboto_Mono } from "next/font/google";
+import { Poppins } from "next/font/google";
 import type { Viewport } from "next";
 import PWARegister from "@/components/pwa_register";
 import "./globals.css";
 
-const robotoSans = Roboto({
+const poppinsSans = Poppins({
   variable: "--font-geist-sans",
   weight: ["100", "300", "400", "500", "700", "900"],
   subsets: ["latin"],
 });
 
-const robotoMono = Roboto_Mono({
+const poppinsMono = Poppins({
   variable: "--font-geist-mono",
   weight: ["100", "300", "400", "500", "700"],
   subsets: ["latin"],
@@ -31,7 +31,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${robotoSans.variable} ${robotoMono.variable} ${robotoSans.className}`}>
+      <body className={`${poppinsSans.variable} ${poppinsMono.variable} ${poppinsSans.className}`}>
         <PWARegister />
         {children}
       </body>

--- a/src/components/admin/chat_bot/index.tsx
+++ b/src/components/admin/chat_bot/index.tsx
@@ -5,6 +5,7 @@ import { SweetAlert2, Fetch_toFile, Fetch_to } from "@/utilities";
 import api_link from "@/config/conf/json_config/fetch_url.json";
 import Swal from "sweetalert2";
 import Markdown from "react-markdown";
+import { useRouter } from "next/navigation";
 
 interface PdfFile {
     id?: number;
@@ -16,6 +17,7 @@ interface PdfFile {
 const PAGE_SIZE = 30;
 
 export default function Chat_bot() {
+    const router = useRouter();
     const fileRef = useRef<HTMLInputElement>(null);
     const [data, setData] = useState<PdfFile[]>([]);
     const [refresh, setRefresh] = useState(false);
@@ -146,6 +148,7 @@ export default function Chat_bot() {
             <section className={styles.status}>
                 <span>
                     <h2>Your Documents</h2>
+                    <button className={styles.button_upload} onClick={() => {router.push("/chat_bot");}}>Open Chatbot</button>
                     <button className={styles.button_upload} onClick={UploadPdf}>Upload PDF File</button>
                 </span>
                 <div>


### PR DESCRIPTION
This pull request updates the font used throughout the application from Roboto to Poppins and introduces a new navigation button to the chatbot admin interface. The most important changes are grouped below by theme.

**Font update:**

* Replaced all instances of the `Roboto` and `Roboto_Mono` fonts with `Poppins` for both sans and mono variants in `src/app/layout.tsx`, and updated the body class names accordingly to apply the new fonts site-wide. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L2-R13) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L34-R34)

**Admin chatbot interface improvements:**

* Added a new "Open Chatbot" button in the admin chatbot interface (`src/components/admin/chat_bot/index.tsx`) that uses the Next.js `useRouter` hook to navigate to the `/chat_bot` page. [[1]](diffhunk://#diff-72ee7700de3372e1e87b2f05b7ec2c90090b2de12f0648a70a481232ffcf7d66R8) [[2]](diffhunk://#diff-72ee7700de3372e1e87b2f05b7ec2c90090b2de12f0648a70a481232ffcf7d66R20) [[3]](diffhunk://#diff-72ee7700de3372e1e87b2f05b7ec2c90090b2de12f0648a70a481232ffcf7d66R151)…Chat_bot component