### PR TITLE
Replace Poppins font with Inter font in layout component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,16 @@
 import { MetadataUtils } from "@/utilities";
-import { Poppins } from "next/font/google";
+import { Inter } from "next/font/google";
 import type { Viewport } from "next";
 import PWARegister from "@/components/pwa_register";
 import "./globals.css";
 
-const poppinsSans = Poppins({
+const interSans = Inter({
   variable: "--font-geist-sans",
   weight: ["100", "300", "400", "500", "700", "900"],
   subsets: ["latin"],
 });
 
-const poppinsMono = Poppins({
+const interMono = Inter({
   variable: "--font-geist-mono",
   weight: ["100", "300", "400", "500", "700"],
   subsets: ["latin"],
@@ -31,7 +31,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${poppinsSans.variable} ${poppinsMono.variable} ${poppinsSans.className}`}>
+      <body className={`${interSans.variable} ${interMono.variable} ${interSans.className}`}>
         <PWARegister />
         {children}
       </body>


### PR DESCRIPTION
This pull request updates the application's font from Poppins to Inter throughout the `src/app/layout.tsx` file for both sans and mono font variants. The change ensures consistent use of the Inter font family in the app's layout.

Font update:

* Replaced all imports and usage of the `Poppins` font with the `Inter` font, updating both the sans and mono variants and their associated variables and class names in `src/app/layout.tsx`. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L2-R13) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L34-R34)