### PR TITLE
Improve button colors for visibility in chat and profile components

### DIFF
--- a/src/components/chat/main/css/styles.module.css
+++ b/src/components/chat/main/css/styles.module.css
@@ -268,6 +268,7 @@
     box-shadow: 0 0 2px 1px var(--default-color-gray);
     border: transparent;
     cursor: pointer;
+    color: var(--default-color-white);
     transition: all 1s ease;
 }
 .welcome_intro button:hover {

--- a/src/components/chat/profile/css/styles.module.css
+++ b/src/components/chat/profile/css/styles.module.css
@@ -104,6 +104,7 @@
     background-color: var(--primary);
     border: transparent;
     border-radius: 5px;
+    color: var(--default-color-white);
 }
 .deleteaccount {
     width: 100%;

--- a/src/components/chat/sidebars/css/styles.module.css
+++ b/src/components/chat/sidebars/css/styles.module.css
@@ -40,15 +40,12 @@
     font-size: 0.9rem;
     margin: 5rem 0 0 0;
     position: relative;
+    color: var(--default-color-white);
 }
 .options button:active {
     opacity: 0.5;
 }
-.options_svg {
-    position: absolute;
-    left: 50px;
-    bottom: 25%;
-}
+
 .search_pdf {
     width: 100%;
     height: 50px;

--- a/src/components/chat/sidebars/index.tsx
+++ b/src/components/chat/sidebars/index.tsx
@@ -197,11 +197,6 @@ export default function Sidebars({ isOpen, emailRes, setCurrentPdf, globalRefres
             <div className={`${styles.wrapper}`}>
                 <section className={styles.options}>
                     <button onClick={UploadPdf} title="Upload your pdf" >
-                        <svg className={styles.options_svg} width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M12 16V4" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-                        <path d="M8 8L12 4L16 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-                        <path d="M4 20H20" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-                        </svg>
                         Upload New PDF
                     </button>
                     <input 


### PR DESCRIPTION
This pull request makes several UI improvements to the chat component styles, focusing on button appearance and sidebar layout. The main changes ensure more consistent button text color across the application and simplify the sidebar's upload button by removing the SVG icon.

Button styling consistency:

* Added `color: var(--default-color-white);` to buttons in `welcome_intro`, `profile`, and `sidebars` modules to ensure button text is always white for better readability and a consistent look. [[1]](diffhunk://#diff-bf9753f66f002e2c68b8debdf3de55171876fd5baa2f3f85fb4aec91c3276452R271) [[2]](diffhunk://#diff-d5f367417b8111e927637a815754b813ad0b1e1437ba9f9b3e01ccce13b34cfdR107) [[3]](diffhunk://#diff-31da2e018d5d9bc8c34ffcb39c72e31d71efa8d51f9197bc183adbb88e020979R43-R48)

Sidebar UI simplification:

* Removed the SVG icon from the "Upload New PDF" button in the sidebar, leaving only the text label for a cleaner appearance.
* Deleted the unused `.options_svg` CSS class from the sidebar styles, reflecting the removal of the icon.… components