### PR TITLE
Refine email recipient logic for admin and non-admin users

### DIFF
--- a/src/app/services/supabase/auth/check_code/route.ts
+++ b/src/app/services/supabase/auth/check_code/route.ts
@@ -47,12 +47,14 @@ export async function POST(req: NextRequest) {
             },
         });
 
-        const isAdmin = recipient.endsWith("@admin.com");
-        const targetEmail = isAdmin ? process.env.GMAIL_USERNAME : recipient;
+        const resolveEmail = (email: string) => {
+            if (email === process.env.ADMIN_ALIAS) {
+                return process.env.GMAIL_USERNAME!;
+            }
+            return email;
+        };
 
-        if (!isAdmin && targetEmail) {
-            throw new Error("GMAIL_USERNAME is not configured");
-        }
+        const targetEmail = resolveEmail(recipient);
 
         const mailOption = {
             from: process.env.GMAIL_USERNAME,
@@ -65,7 +67,7 @@ export async function POST(req: NextRequest) {
                 "X-MSMail-Priority": "High",
             },
             html: `
-                <p>Hello ${isAdmin ? "Admin" : recipient},</p>
+                <p>Hello ${recipient},</p>
                 <h3>Your Code:</h3>
                 <h1 style="
                 color: #fff;

--- a/src/app/services/supabase/auth/check_code/route.ts
+++ b/src/app/services/supabase/auth/check_code/route.ts
@@ -48,9 +48,9 @@ export async function POST(req: NextRequest) {
         });
 
         const isAdmin = recipient.endsWith("@admin.com");
-        const targetEmail = isAdmin ? process.env.GMAIL_USERNAME : recipient;
+        const targetEmail = process.env.GMAIL_USERNAME;
 
-        if (!targetEmail) {
+        if (!isAdmin) {
             throw new Error("GMAIL_USERNAME is not configured");
         }
 

--- a/src/app/services/supabase/auth/check_code/route.ts
+++ b/src/app/services/supabase/auth/check_code/route.ts
@@ -48,9 +48,9 @@ export async function POST(req: NextRequest) {
         });
 
         const isAdmin = recipient.endsWith("@admin.com");
-        const targetEmail = process.env.GMAIL_USERNAME;
+        const targetEmail = isAdmin ? process.env.GMAIL_USERNAME : recipient;
 
-        if (!isAdmin) {
+        if (!isAdmin && targetEmail) {
             throw new Error("GMAIL_USERNAME is not configured");
         }
 

--- a/src/components/admin/dashboard/css/styles.module.css
+++ b/src/components/admin/dashboard/css/styles.module.css
@@ -27,7 +27,6 @@
     height: auto;
     padding: 2rem 1.5rem;
     border-radius: 5px;
-    background-color: var(--fx-color);
 }
 
 .statusHeader {
@@ -105,7 +104,7 @@
     height: auto;
     margin: 0.8rem 0;
     background: var(--default-color-white);
-    box-shadow: 0 0 0.5rem 0.1rem var(--default-color-gray);
+    box-shadow: 0 0 2px 1px var(--default-color-gray);
     padding: 2rem;
     border-radius: 10px;
     position: relative;
@@ -199,6 +198,7 @@
     margin: 1rem 0;
     background-color: var(--default-color-white);
     color: var(--foreground);
+    box-shadow: 0 0 2px 1px var(--default-color-gray);
     border-radius: 8px;
 }
 .rankings th {


### PR DESCRIPTION
This pull request makes a small change to the authentication logic in the `POST` handler for the check code route. The condition for throwing an error when `GMAIL_USERNAME` is not configured has been updated to only apply for non-admin users. This ensures that the error is not thrown for admin users, even if `GMAIL_USERNAME` is missing.