### PR TITLE
Enhance authentication flow with mobile parameter handling

### DIFF
--- a/src/app/(pages)/auth/create-password/page.tsx
+++ b/src/app/(pages)/auth/create-password/page.tsx
@@ -1,9 +1,33 @@
+"use client";
 import { Create_Password } from "@/components/auth";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 
-export default function CreatePasswordPage() {
+function CreatePasswordContent() {
+    const searchParams = useSearchParams();
+    const mobile = searchParams.get('mobile');
+    const [inMobile, setInMobile] = useState(false);
+
+    useEffect(() => {
+        function mobileCheck() {
+            if (mobile) return setInMobile(true);
+            setInMobile(false);
+        }
+        mobileCheck();
+    }, [mobile]);
+
+
     return(
         <main className="auth_page">
-            <Create_Password />
+            <Create_Password mobile={inMobile} />
         </main>
+    );
+}
+
+export default function CreatePasswordPage() {
+    return (
+        <Suspense fallback={null}>
+            <CreatePasswordContent />
+        </Suspense>
     );
 }

--- a/src/app/(pages)/auth/register/page.tsx
+++ b/src/app/(pages)/auth/register/page.tsx
@@ -2,24 +2,43 @@
 import { SignUp } from "@/components/auth";
 import { Fetch_to } from "@/utilities";
 import api_link from "@/config/conf/json_config/fetch_url.json";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 
-export default function SignupPage() {
+function SignupContent() {
     const router = useRouter();
+    const searchParams = useSearchParams();
+    const mobile = searchParams.get('mobile');
+    const [inMobile, setInMobile] = useState(false);
 
     useEffect(() => {
             async function check() {
                 const response = await Fetch_to(api_link.jwt.verify);
-                if (response.success) return router.push("/chat");
+                if(!response.success) return;
+                const response_admin = response.data.message.final_data.data[0].email;
+                if (response.success && response_admin === "admin@admin.com") return router.push("/admin/dashboard");
+                return router.push("/chat");
             }
             check();
-        }, []);
+            function mobileCheck() {
+                if (mobile) return setInMobile(true);
+                setInMobile(false);
+            }
+            mobileCheck();
+        }, [mobile]);
 
     return(
         <main className="auth_page">
-            <SignUp />
+            <SignUp mobile={inMobile} />
         </main>
     );
 
+}
+
+export default function SignUpPage() {
+    return (
+        <Suspense fallback={null}>
+            <SignupContent />
+        </Suspense>
+    );
 }

--- a/src/app/(pages)/auth/signin/page.tsx
+++ b/src/app/(pages)/auth/signin/page.tsx
@@ -11,7 +11,10 @@ export default function SignInPage() {
     useEffect(() => {
         async function check() {
             const response = await Fetch_to(api_link.jwt.verify);
-            if (response.success) return router.push("/chat");
+            if(!response.success) return;
+            const response_admin = response.data.message.final_data.data[0].email;
+            if (response.success && response_admin === "admin@admin.com") return router.push("/admin/dashboard");
+            return router.push("/chat");
         }
         check();
     }, []);

--- a/src/components/auth/create_password/index.tsx
+++ b/src/components/auth/create_password/index.tsx
@@ -13,7 +13,11 @@ import {
     useConfirmExit
 } from "@/utilities";
 
-export default function Create_Password() {
+type HeaderProps = {
+    mobile: boolean;
+}
+
+export default function Create_Password({ mobile }: HeaderProps) {
     const router = useRouter();
 
     const [form, setForm] = useState({
@@ -24,8 +28,14 @@ export default function Create_Password() {
     const [loading, setLoading] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
     const [showPassword2, setShowPassword2] = useState(false);
+    const [showSignin, setShowSignin] = useState(false);
 
     usePreventExit(true);
+
+    useEffect(() => {
+        if (mobile) return setShowSignin(false);
+        setShowSignin(true);
+    }, [mobile]);
 
     const confirmExit = useConfirmExit({
         onConfirm: () => router.push("/auth/register")
@@ -57,6 +67,7 @@ export default function Create_Password() {
             if (autosignin_response.success) {
                 localStorage.clear();
                 await Fetch_to(api_link.jwt.auth, { email: form.email });
+                if (showSignin) return (window as Window & { ReactNativeWebView?: { postMessage: (message: string) => void } }).ReactNativeWebView?.postMessage("closeWebView");
                 router.push("/chat");
             } else {
                 alert(responds.message);
@@ -143,7 +154,7 @@ export default function Create_Password() {
                         </span>
                         <section className={`${styles.buttons} `}>
                             <button type="button" onClick={() => { if(confirmExit()) return router.push("/auth/register");  }} style={{backgroundColor: "var(--secondary)"}}>Back</button>
-                            <button>Activate</button>
+                            <button>Register</button>
                         </section>
                     </form>
                 )}

--- a/src/components/auth/register/index.tsx
+++ b/src/components/auth/register/index.tsx
@@ -13,7 +13,11 @@ import {
     Progress
 } from "@/utilities";
 
-export default function SignUp() {
+type HeaderProps = {
+    mobile: boolean;
+}
+
+export default function SignUp({ mobile }: HeaderProps) {
     const router = useRouter();
 
     const [form, setForm] = useState({
@@ -25,8 +29,14 @@ export default function SignUp() {
     const [isDirty, setIsDirty] = useState(false);
     const [ifMinors, setIfMinors] = useState(true);
     const [ifTeaher, setIfTeacher] = useState(false);
+    const [showSignin, setShowSignin] = useState(false);
 
     usePreventExit(isDirty);
+
+    useEffect(() => {
+        if (mobile) return setShowSignin(false);
+        setShowSignin(true);
+    }, [mobile]);
 
     useEffect(() => {
         if (form.year == "Kinder Garten" ) {
@@ -198,7 +208,9 @@ export default function SignUp() {
                         <section className={`${styles.buttons} `}>
                             <button>Register</button>
                         </section>
-                        <p >Already have an Account? <Link href={"/auth/signin"} onClick={() => {Progress(true);}}>Sign In</Link></p>
+                        {showSignin ? (
+                            <p >Already have an Account? <Link href={"/auth/signin"} onClick={() => {Progress(true);}}>Sign In</Link></p>
+                        ) : null}
                     </form>
                 )}
             </div>


### PR DESCRIPTION
This pull request updates the authentication flow to better support mobile environments and improves admin user routing. The main changes include passing a `mobile` prop to the registration and password creation components, adjusting UI and logic based on this prop, and refining navigation for admin users. Additionally, the user experience is improved with changes to button labeling and conditional rendering of the "Sign In" link.

**Mobile support and UI adjustments:**
- The `SignUp` and `Create_Password` components now accept a `mobile` prop, which is determined from the URL's search parameters and passed down from their respective page components. This enables the UI and logic to adapt based on whether the user is on a mobile device. (`src/app/(pages)/auth/register/page.tsx`, `src/app/(pages)/auth/create-password/page.tsx`, `src/components/auth/register/index.tsx`, `src/components/auth/create_password/index.tsx`) [[1]](diffhunk://#diff-4cbfa5d7f9c17b9bf6151c83518a3e9e24a964f77a376bb9b330338d592bca4cL5-R44) [[2]](diffhunk://#diff-1082efff0615a1e8a101af23419336aea3848530b1043e4291b43825ba0a66c0R1-R33) [[3]](diffhunk://#diff-cc40f711095630de2ad3a69370897306ae117abbf1e97111b3d336a4711d0221L16-R20) [[4]](diffhunk://#diff-46022ad136390545611895cd145cfffc003b40d3a07d6da45922d749c5ebfcceL16-R20)

- The "Already have an Account? Sign In" link in the registration form is now conditionally rendered based on the `mobile` prop, hiding it for mobile users. (`src/components/auth/register/index.tsx`) [[1]](diffhunk://#diff-cc40f711095630de2ad3a69370897306ae117abbf1e97111b3d336a4711d0221R32-R40) [[2]](diffhunk://#diff-cc40f711095630de2ad3a69370897306ae117abbf1e97111b3d336a4711d0221R211-R213)

**Navigation and routing improvements:**
- After successful authentication, admin users are now redirected to `/admin/dashboard` instead of `/chat`. This logic is applied to both the registration and sign-in flows. (`src/app/(pages)/auth/register/page.tsx`, `src/app/(pages)/auth/signin/page.tsx`) [[1]](diffhunk://#diff-4cbfa5d7f9c17b9bf6151c83518a3e9e24a964f77a376bb9b330338d592bca4cL5-R44) [[2]](diffhunk://#diff-645c55c2b34122bac816e503f132dfede707d1e8b31e7d8e33e451cb6f3606ecL14-R17)

- In the password creation flow, if the user is on mobile, a message is sent to close the webview after successful registration; otherwise, the user is redirected to `/chat`. (`src/components/auth/create_password/index.tsx`) [[1]](diffhunk://#diff-46022ad136390545611895cd145cfffc003b40d3a07d6da45922d749c5ebfcceR31-R39) [[2]](diffhunk://#diff-46022ad136390545611895cd145cfffc003b40d3a07d6da45922d749c5ebfcceR70)

**UI/UX improvements:**
- The "Activate" button in the password creation form has been relabeled to "Register" for clarity. (`src/components/auth/create_password/index.tsx`)… and conditional rendering in CreatePassword and SignUp components