### PR TITLE
Enhance response handling in SignupContent for mobile users

### DIFF
--- a/src/app/(pages)/auth/register/page.tsx
+++ b/src/app/(pages)/auth/register/page.tsx
@@ -14,7 +14,7 @@ function SignupContent() {
     useEffect(() => {
             async function check() {
                 const response = await Fetch_to(api_link.jwt.verify);
-                if(!response.success) return;
+                if(!response.success || inMobile) return;
                 const response_admin = response.data.message.final_data.data[0].email;
                 if (response.success && response_admin === "admin@admin.com") return router.push("/admin/dashboard");
                 return router.push("/chat");


### PR DESCRIPTION
This pull request makes a small adjustment to the authentication flow in the registration page. Now, if the user is on a mobile device, the redirect logic after verifying the JWT will be skipped, in addition to the existing check for unsuccessful responses. 

- Updated the JWT verification logic in `SignupContent` to also return early if the user is on a mobile device, preventing further redirect logic in that case (`src/app/(pages)/auth/register/page.tsx`).…y routing for mobile users