### PR TITLE
Ensure JWT fetch after successful auto sign-in in CreatePassword

### DIFF
--- a/src/components/auth/create_password/index.tsx
+++ b/src/components/auth/create_password/index.tsx
@@ -66,8 +66,8 @@ export default function Create_Password({ mobile }: HeaderProps) {
 
             if (autosignin_response.success) {
                 localStorage.clear();
-                await Fetch_to(api_link.jwt.auth, { email: form.email });
                 if (showSignin) return (window as Window & { ReactNativeWebView?: { postMessage: (message: string) => void } }).ReactNativeWebView?.postMessage("closeWebView");
+                await Fetch_to(api_link.jwt.auth, { email: form.email });
                 router.push("/chat");
             } else {
                 alert(responds.message);


### PR DESCRIPTION
This pull request makes a minor adjustment to the `Create_Password` component's sign-in flow. The only change is to move the `Fetch_to` call after a conditional check for `showSignin`, ensuring that the fetch only occurs when the sign-in flow continues.

Most important change:

* Moved the `Fetch_to(api_link.jwt.auth, { email: form.email })` call to execute only if the `showSignin` condition is not met, preventing unnecessary API calls when closing the WebView.…n-in in CreatePassword component