### PR TITLE
Add mobile parameter handling and update rendering in Confirm_email_signin

### DIFF
--- a/src/app/(pages)/auth/confirm-email-signin/page.tsx
+++ b/src/app/(pages)/auth/confirm-email-signin/page.tsx
@@ -1,9 +1,32 @@
+"use client";
 import { Confirm_email_signin } from "@/components/auth";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+function ConfirmEmailSigninContent() {
+    const searchParams = useSearchParams();
+    const mobile = searchParams.get('mobile');
+    const [inMobile, setInMobile] = useState(false);
+
+    useEffect(() => {
+        function mobileCheck() {
+            if (mobile) return setInMobile(true);
+            setInMobile(false);
+        }
+        mobileCheck();
+    }, [mobile]);
+
+    return(
+        <main className="auth_page">
+            <Confirm_email_signin mobile={inMobile} />
+        </main>
+    );
+}
 
 export default function ConfirmEmailSigninPage() {
     return(
-        <main className="auth_page">
-            <Confirm_email_signin />
-        </main>
+        <Suspense fallback={null} >
+            <ConfirmEmailSigninContent />
+        </Suspense>
     );
 }

--- a/src/components/auth/confirm_email_signin/index.tsx
+++ b/src/components/auth/confirm_email_signin/index.tsx
@@ -11,7 +11,11 @@ import {
     useConfirmExit
 } from "@/utilities";
 
-export default function Confirm_email_signin() {
+type HeaderProps = {
+    mobile: boolean;
+}
+
+export default function Confirm_email_signin({ mobile }: HeaderProps) {
     const router = useRouter();
 
     const [form, setForm] = useState({
@@ -20,6 +24,12 @@ export default function Confirm_email_signin() {
     const [status, setStatus] = useState(false);
     const [message, setMessage] = useState("");
     const [loading, setLoading] = useState(false);
+    const [showSignin, setShowSignin] = useState(false);
+
+    useEffect(() => {
+        if (mobile) return setShowSignin(false);
+        setShowSignin(true);
+    }, [mobile]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setForm({ ...form, [e.target.name]: e.target.value });
@@ -58,6 +68,7 @@ export default function Confirm_email_signin() {
                 setMessage(response.message);
                 setStatus(true);
                 setLoading(false);
+                if (showSignin) return (window as Window & { ReactNativeWebView?: { postMessage: (message: string) => void } }).ReactNativeWebView?.postMessage("closeWebView");
                 return;
             }
             await Fetch_to(api_link.jwt.auth, { email: form.email });


### PR DESCRIPTION
This pull request updates the email sign-in confirmation flow to better support mobile and web contexts. It introduces logic to detect if the user is accessing the page from a mobile device via a URL parameter and adjusts the component's behavior accordingly. The main changes are grouped below:

**Mobile Detection and Behavior:**

* Added logic in `ConfirmEmailSigninPage` (`page.tsx`) to check for a `mobile` query parameter using `useSearchParams`, and pass a `mobile` prop to the `Confirm_email_signin` component.
* Updated `Confirm_email_signin` component (`index.tsx`) to accept a `mobile` prop and use it to control the display of the sign-in form and subsequent behavior. [[1]](diffhunk://#diff-a06af12ddb93e4276c2b1e5310f9c564777cb8c5b15cbb66b195d919c196fa07L14-R18) [[2]](diffhunk://#diff-a06af12ddb93e4276c2b1e5310f9c564777cb8c5b15cbb66b195d919c196fa07R27-R32)

**Conditional WebView Handling:**

* Modified the sign-in confirmation logic so that, when in a mobile context, a message is sent to close the WebView after successful confirmation, using the `ReactNativeWebView` API.

**Component Structure and Rendering:**

* Refactored the page component to wrap the content in a `Suspense` boundary, ensuring proper handling of asynchronous rendering.… and update rendering logic