### PR TITLE
Enhance Confirm_email_signin with mobile parameter support

### DIFF
--- a/src/app/(pages)/auth/confirm-email-signin/page.tsx
+++ b/src/app/(pages)/auth/confirm-email-signin/page.tsx
@@ -18,7 +18,7 @@ function ConfirmEmailSigninContent() {
 
     return(
         <main className="auth_page">
-            <Confirm_email_signin mobile={inMobile} />
+            <Confirm_email_signin mobile={inMobile} email={`${mobile}`} />
         </main>
     );
 }

--- a/src/components/auth/confirm_email_signin/index.tsx
+++ b/src/components/auth/confirm_email_signin/index.tsx
@@ -13,9 +13,10 @@ import {
 
 type HeaderProps = {
     mobile: boolean;
+    email: string;
 }
 
-export default function Confirm_email_signin({ mobile }: HeaderProps) {
+export default function Confirm_email_signin({ mobile, email }: HeaderProps) {
     const router = useRouter();
 
     const [form, setForm] = useState({
@@ -28,6 +29,7 @@ export default function Confirm_email_signin({ mobile }: HeaderProps) {
 
     useEffect(() => {
         if (mobile) return setShowSignin(false);
+        console.log(email);
         setShowSignin(true);
     }, [mobile]);
 
@@ -37,7 +39,8 @@ export default function Confirm_email_signin({ mobile }: HeaderProps) {
 
    useEffect(() => {
         const saveEmail = localStorage.getItem("email");
-        setForm(prev => ({ ...prev, email: saveEmail || `${mobile}` }));
+        
+        setForm(prev => ({ ...prev, email: saveEmail || "" }));
     }, []);
 
     const confirmExit = useConfirmExit({

--- a/src/components/auth/confirm_email_signin/index.tsx
+++ b/src/components/auth/confirm_email_signin/index.tsx
@@ -37,7 +37,7 @@ export default function Confirm_email_signin({ mobile }: HeaderProps) {
 
    useEffect(() => {
         const saveEmail = localStorage.getItem("email");
-        setForm(prev => ({ ...prev, email: saveEmail || "" }));
+        setForm(prev => ({ ...prev, email: saveEmail || `${mobile}` }));
     }, []);
 
     const confirmExit = useConfirmExit({


### PR DESCRIPTION
This pull request updates the email confirmation sign-in flow by passing the user's email as a prop and logging it for debugging. The changes ensure the `Confirm_email_signin` component consistently receives the email value and improve state initialization.

**Component interface and data flow:**

* Added an `email` prop to the `Confirm_email_signin` component and updated its usage in `page.tsx` to pass the email value as a string. [[1]](diffhunk://#diff-227f2384807b9c827ddf935f3eb84bf8c0c5358cb1457d834b9f342648b14899L21-R21) [[2]](diffhunk://#diff-a06af12ddb93e4276c2b1e5310f9c564777cb8c5b15cbb66b195d919c196fa07R16-R19)

**Debugging and state management:**

* Added a `console.log(email)` statement in the `Confirm_email_signin` component to log the email prop for debugging purposes.
* Improved the initialization of the `form.email` state by retrieving the value from local storage, ensuring the form is pre-filled if possible.