### PR TITLE
Fix email handling in ConfirmEmailSignin form state

### DIFF
--- a/src/components/auth/confirm_email_signin/index.tsx
+++ b/src/components/auth/confirm_email_signin/index.tsx
@@ -29,7 +29,7 @@ export default function Confirm_email_signin({ mobile, email }: HeaderProps) {
 
     useEffect(() => {
         if (mobile) return setShowSignin(false);
-        console.log(email);
+        setForm(prev => ({ ...prev, email: email }));
         setShowSignin(true);
     }, [mobile]);
 
@@ -38,8 +38,8 @@ export default function Confirm_email_signin({ mobile, email }: HeaderProps) {
     };
 
    useEffect(() => {
+        if (mobile) return;
         const saveEmail = localStorage.getItem("email");
-        
         setForm(prev => ({ ...prev, email: saveEmail || "" }));
     }, []);
 


### PR DESCRIPTION
This pull request makes small improvements to the `Confirm_email_signin` component to ensure the email value is properly set in the form state based on the user's device and stored data.

- When the component detects a non-mobile device, it now sets the form's email field to the provided `email` prop instead of just logging it.
- The effect that loads the email from `localStorage` now only runs for non-mobile devices, preventing unnecessary updates on mobile.…correctly