### PR TITLE
Improve response handling in POST routes and token management

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  
 };
 
 export default nextConfig;

--- a/src/app/services/jwt/auth/route.ts
+++ b/src/app/services/jwt/auth/route.ts
@@ -44,5 +44,5 @@ export async function POST(req: NextRequest) {
 
     console.log(" ==> User is Successfully Log In");
 
-    return NextResponse.json({ success: true }, { status: 200 });
+    return NextResponse.json({ success: true, token }, { status: 200 });
 }

--- a/src/app/services/jwt/deauth/route.ts
+++ b/src/app/services/jwt/deauth/route.ts
@@ -11,7 +11,7 @@ export async function POST() {
         name: "token", 
         value: "",        
         httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
+        secure: process.env.PRODUCTION === "production",
         sameSite: "strict",
         path: "/",        
         maxAge: 0, 

--- a/src/app/services/jwt/verify/route.ts
+++ b/src/app/services/jwt/verify/route.ts
@@ -1,24 +1,21 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import jwt from "jsonwebtoken";
 import { cookies } from "next/headers";
 
-export async function POST() {
-    const token = (await cookies()).get("token")?.value;
+export async function POST(req: NextRequest) {
+  const auth = req.headers.get("authorization") || "";
+  const bearer = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  const cookieToken = (await cookies()).get("token")?.value;
+  const token = bearer || cookieToken;
 
-    const apikey = process.env.API_KEY;
+  const apikey = process.env.API_KEY;
+  if (!apikey) return NextResponse.json({ success: false, error: "API is not Valid" }, { status: 401 });
+  if (!token) return NextResponse.json({ success: false, error: "UnAuth" }, { status: 403 });
 
-    if (!apikey) return NextResponse.json({ success: false, error: "API is not Valid" }, { status: 401 });
-
-    if (!token) {
-        return NextResponse.json({ success: false, error: "UnAuth" }, { status: 401 });
-    }
-
-    try {
-        const decoded = jwt.verify(token, process.env.JWT_SECRET || "");
-        if (!decoded) return NextResponse.json({ success: false, error: "Secret Not Found" }, { status: 404 });
-        console.log(" ==> User Authenticated", token);
-        return NextResponse.json({ success: true, message: decoded}, { status: 200 });
-    } catch {
-        return NextResponse.json({ success: false, error: "UnAuth" }, { status: 401 });
-    }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || "");
+    return NextResponse.json({ success: true, message: decoded }, { status: 200 });
+  } catch {
+    return NextResponse.json({ success: false, error: "UnAuth" }, { status: 401 });
+  }
 }

--- a/src/components/auth/confirm_email_signin/index.tsx
+++ b/src/components/auth/confirm_email_signin/index.tsx
@@ -28,8 +28,8 @@ export default function Confirm_email_signin({ mobile, email }: HeaderProps) {
     const [showSignin, setShowSignin] = useState(false);
 
     useEffect(() => {
-        if (mobile) return setShowSignin(false);
         setForm(prev => ({ ...prev, email: email }));
+        if (mobile) return setShowSignin(false);
         setShowSignin(true);
     }, [mobile]);
 
@@ -65,8 +65,8 @@ export default function Confirm_email_signin({ mobile, email }: HeaderProps) {
         setLoading(true);
         const responds = await Fetch_to(api_link.checkcode, { email: form.email, code: form.code });
         if (responds.success) {
+            if (!showSignin) return (window as Window & { ReactNativeWebView?: { postMessage: (message: string) => void } }).ReactNativeWebView?.postMessage(`${form.code}`);
             localStorage.clear();
-            if (showSignin) return (window as Window & { ReactNativeWebView?: { postMessage: (message: string) => void } }).ReactNativeWebView?.postMessage(`${form.code}`);
             const response = await Fetch_to(api_link.checkcode, { email: form.email, code: form.code, key: "confirm_code" });
             if (!response.success) {
                 setMessage(response.message);


### PR DESCRIPTION
This pull request introduces several improvements and fixes across authentication service routes and the email sign-in confirmation component. The main focus is on enhancing JWT authentication handling, correcting environment variable usage, and refining the logic for email sign-in confirmation.

**Authentication Service Improvements:**

* The JWT verification endpoint (`src/app/services/jwt/verify/route.ts`) now supports extracting tokens from both the `Authorization` header (as a Bearer token) and cookies, improving compatibility with different client types. It also adjusts HTTP status codes for missing tokens and simplifies error handling.
* The login endpoint (`src/app/services/jwt/auth/route.ts`) now returns the JWT token in the response body upon successful login, enabling clients to easily retrieve and store the token.
* The logout endpoint (`src/app/services/jwt/deauth/route.ts`) fixes the environment variable for setting the `secure` cookie flag, switching from `NODE_ENV` to `PRODUCTION` for consistency with deployment configuration.

**Email Sign-in Confirmation Logic:**

* The email sign-in confirmation component (`src/components/auth/confirm_email_signin/index.tsx`) refines its state management and side effects: the logic for showing the sign-in form is now more robust, and the order of operations in the `useEffect` hook is improved for clarity.
* The component also updates the flow for posting the confirmation code to the React Native WebView, ensuring correct behavior based on the `showSignin` state.

**Other:**

* Removes placeholder comment from `next.config.ts` for a cleaner configuration file.…ment